### PR TITLE
re-assign `window[window['JS-Widget']]`

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ function app(window) {
     // for widget's API calls
     globalObject = apiHandler;
     globalObject.configurations = configurations;
+    window[window['JS-Widget']] = globalObject;
 }
 
 /**


### PR DESCRIPTION
I don't understand why you reassign `globalObject` but not `window[window['JS-Widget']]`.

Also, `supportedAPI` seems redundant, line 46 could be moved to replace the default handler at line 56.